### PR TITLE
Unique channels

### DIFF
--- a/src/main/java/org/nrg/xnat/plugin/SnetSleepDataBasicPlugin.java
+++ b/src/main/java/org/nrg/xnat/plugin/SnetSleepDataBasicPlugin.java
@@ -5,7 +5,7 @@ import org.nrg.framework.annotations.XnatPlugin;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 
-@XnatPlugin(value = "snet-plugin", name = "SNET SleepDataBasic", description = "Contains data types for SleepResearchSessionData, psgScanData, psgRecordData",
+@XnatPlugin(value = "snet-plugin", name = "SNET SleepDataBasic", description = "Contains data types for SleepResearchSessionData and psgScanData",
         dataModels = {@XnatDataModel(value = "snet01:SleepResearchSession",
                                      singular = "Sleep Research Session",
                                      plural = "Sleep Research Sessions",
@@ -13,10 +13,6 @@ import org.springframework.context.annotation.ComponentScan;
                       @XnatDataModel(value = "snet01:psgScanData",
                                      singular = "PSG Recording",
                                      plural = "PSG Recordings",
-                                     code = "PSG"),
-                      @XnatDataModel(value = "snet01:psgRecordData",
-                                     singular = "EDF Channel",
-                                     plural = "EDF Channels",
-                                     code = "CHA")})
+                                     code = "PSG")})
 public class SnetSleepDataBasicPlugin {
 }

--- a/src/main/java/org/nrg/xnat/plugin/SnetSleepDataBasicPlugin.java
+++ b/src/main/java/org/nrg/xnat/plugin/SnetSleepDataBasicPlugin.java
@@ -5,22 +5,18 @@ import org.nrg.framework.annotations.XnatPlugin;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 
-@XnatPlugin(value = "snet-plugin", name = "SNET SleepDataBasic", description = "The SnetSleepDataBasicPlugin contains data types for SleepResearchSessionData, psgScanData, psgEDFData and psgRecordData",
+@XnatPlugin(value = "snet-plugin", name = "SNET SleepDataBasic", description = "Contains data types for SleepResearchSessionData, psgScanData, psgRecordData",
         dataModels = {@XnatDataModel(value = "snet01:SleepResearchSession",
-                                       singular = "Sleep Research Session",
-                                       plural = "Sleep Research Session",
-                                       code = "SRS"),
+                                     singular = "Sleep Research Session",
+                                     plural = "Sleep Research Sessions",
+                                     code = "SRS"),
                       @XnatDataModel(value = "snet01:psgScanData",
-                                       singular = "PSG Recording",
-                                       plural = "PSG Recordings",
-                                       code = "PSG"),
-                      @XnatDataModel(value = "snet01:psgEDFData",
-                                       singular = "EDF Recording",
-                                       plural = "EDF Recordings",
-                                       code = "EDF"),
+                                     singular = "PSG Recording",
+                                     plural = "PSG Recordings",
+                                     code = "PSG"),
                       @XnatDataModel(value = "snet01:psgRecordData",
-                                       singular = "EDF Channel",
-                                       plural = "EDF Channels",
-                                       code = "CHA")})
+                                     singular = "EDF Channel",
+                                     plural = "EDF Channels",
+                                     code = "CHA")})
 public class SnetSleepDataBasicPlugin {
 }

--- a/src/main/resources/META-INF/resources/templates/screens/snet01_psgScanData/snet01_psgScanData_details.vm
+++ b/src/main/resources/META-INF/resources/templates/screens/snet01_psgScanData/snet01_psgScanData_details.vm
@@ -1,10 +1,10 @@
 #set ($user = $data.getSession().getAttribute("userHelper"))
 #set ($nrScans = $om.getSortedScans().size())
-#set ($nrRecords = $user.getQueryResultsAsArrayList("SELECT * FROM snet01_psgrecorddata").size()) 
+#set ($nrRecords = $user.getQueryResultsAsArrayList("SELECT * FROM snet01_psgscandata_record").size()) 
 #set ($recordCount = $scanCounter+$nrScans)
-#set ($test = $scan.getProperty("xnat_imagescandata_id"))
-#set ($query = "SELECT snet01_psgscandata_records_id FROM snet01_psgscandata_records WHERE snet01_psgscandata_xnat_imagescandata_id = $test")
-#set ($recordsPKs = $user.getQueryResultsAsArrayList($query))
+#set ($imageScanId = $scan.getProperty("xnat_imagescandata_id"))
+#set ($query = "SELECT channelnumberdevice, labeldevice, samplingrate FROM snet01_psgscandata_record WHERE records_record_snet01_psgscanda_xnat_imagescandata_id = $imageScanId ORDER BY channelnumberdevice")
+#set ($records = $user.getQueryResultsAsArrayList($query))
 
 <table>
 	#if($scan.getProperty("quality"))
@@ -68,34 +68,9 @@
 				<td><strong>Label</strong></td>
 				<td><strong>Samplingrate [Hz]</strong></td>
 			</tr>	
-			#set ($array = [])	
-			#foreach($records in $recordsPKs)
-				#foreach($record in $user.getQueryResultsAsArrayList("SELECT channelnumberdevice, labeldevice, samplingrate FROM snet01_psgrecorddata WHERE snet01_psgscandata_records_snet01_psgscandata_records_id = $records.get(0)"))
-					#set ($void = $array.add([$record.get(0),$record.get(1),$record.get(2),$record.get(3),$record.get(4)]))			
-				#end
-			#end
-			###### sort
-			#set($size=$array.size())
-			#foreach($junk in $array) ##Bubble sort takes n^2 passes
-				#set($actual=-1)##Having trouble with math on $velocityCount -- keeping my own count
-				#foreach($line in $array)
-					#set($actual=$actual+1)
-					#if($velocityCount < $size) 
-						#if ($line.get(0) > $array.get($velocityCount).get(0))
-							#set ($tmp=$array.get($velocityCount))
-							#set ($junk=$array.set($velocityCount,$line))
-							#set ($junk=$array.set($actual,$tmp))
-						#end
-					#end
-				#end
-			#end
-			#foreach($record in $array)
+			#foreach($record in $records)
 					<tr>
-					#if ($record.get(0) < 100)
-						<td>$record.get(0)</td>
-					#else
-						<td>0</td>
-					#end
+					<td>$record.get(0)</td>
 					<td>$record.get(1)</td>
 					<td>$record.get(2)</td>
 					</tr>	

--- a/src/main/resources/schemas/snet01/snet01.xsd
+++ b/src/main/resources/schemas/snet01/snet01.xsd
@@ -3,7 +3,6 @@
     <xs:import namespace="http://nrg.wustl.edu/xnat" schemaLocation="../xnat/xnat.xsd"/>
 	<xs:element name="SleepResearchSession" type="snet01:sleepResearchSessionData"/>         
 	<xs:element name="PSGScan" type="snet01:psgScanData"/>
-	<xs:element name="PSGRecordData" type="snet01:psgRecordData"/>
 
 	<xs:complexType name="sleepResearchSessionData">
 		<xs:annotation>
@@ -35,10 +34,44 @@
 					<xs:element name="durationofrecordhours" type="xs:float" minOccurs="0"/>
 					<xs:element name="continuousdataflag" type="xs:integer" minOccurs="0"/> 
 					<xs:element name="comment" type="xs:string" minOccurs="0"/> 
-					<xs:element name="records" minOccurs="0" maxOccurs="unbounded">
+					<xs:element name="records" minOccurs="0">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element name="record" type="snet01:psgRecordData" minOccurs="0" maxOccurs="unbounded">
+								<xs:element name="record" minOccurs="0" maxOccurs="unbounded">
+									<xs:annotation>
+										<xs:appinfo>
+											<xdat:element displayIdentifiers="labeldevice"/>
+											<xdat:field>
+												<xdat:relation uniqueComposite="scan_id_fk" relationType="single"/>
+											</xdat:field>
+										</xs:appinfo>
+									</xs:annotation>
+									<xs:complexType>
+										<xs:sequence>
+											<xs:element name="labelstandard" type="xs:string" minOccurs="0"/>
+											<xs:element name="channelnumberdevice" type="xs:integer" minOccurs="0"/>
+											<xs:element name="channelnumberstandard" type="xs:integer" minOccurs="0"/>
+											<xs:element name="numberofchunks" type="xs:integer" minOccurs="0"/>
+											<xs:element name="samplingrate" type="xs:string" minOccurs="0"/>
+											<xs:element name="transducertype" type="xs:string" minOccurs="0"/>
+											<xs:element name="physicaldimension" type="xs:string" minOccurs="0"/>
+											<xs:element name="physicalminimum" type="xs:float" minOccurs="0"/>
+											<xs:element name="physicalmaximum" type="xs:float" minOccurs="0"/>
+											<xs:element name="digitalminimum" type="xs:integer" minOccurs="0"/>
+											<xs:element name="digitalmaximum" type="xs:integer" minOccurs="0"/>
+											<xs:element name="prefiltering" type="xs:string" minOccurs="0"/>
+											<xs:element name="samplesinrecord" type="xs:integer" minOccurs="0"/>
+											<xs:element name="reserved" type="xs:string" minOccurs="0"/>
+											<xs:element name="comment" type="xs:string" minOccurs="0"/>
+										</xs:sequence>
+										<xs:attribute name="labeldevice" type="xs:string">
+											<xs:annotation>
+												<xs:appinfo>
+													<xdat:field uniqueComposite="scan_id_fk"/>
+												</xs:appinfo>
+											</xs:annotation>
+										</xs:attribute>
+									</xs:complexType>
 								</xs:element>
 							</xs:sequence>
 						</xs:complexType>
@@ -46,29 +79,5 @@
 				</xs:sequence>
 			</xs:extension>
 		</xs:complexContent>
-	</xs:complexType>
-
-	<xs:complexType name="psgRecordData">
-		<xs:annotation>
-			<xs:documentation>Individual record in PSG</xs:documentation>
-		</xs:annotation>
-		<xs:sequence>
-			<xs:element name="labeldevice" type="xs:string" minOccurs="0"/>
-			<xs:element name="labelstandard" type="xs:string" minOccurs="0"/>
-			<xs:element name="channelnumberdevice" type="xs:integer" minOccurs="0"/>
-			<xs:element name="channelnumberstandard" type="xs:integer" minOccurs="0"/>
-			<xs:element name="numberofchunks" type="xs:integer" minOccurs="0"/>
-			<xs:element name="samplingrate" type="xs:string" minOccurs="0"/>
-			<xs:element name="transducertype" type="xs:string" minOccurs="0"/>
-			<xs:element name="physicaldimension" type="xs:string" minOccurs="0"/>
-			<xs:element name="physicalminimum" type="xs:float" minOccurs="0"/>
-			<xs:element name="physicalmaximum" type="xs:float" minOccurs="0"/>
-			<xs:element name="digitalminimum" type="xs:integer" minOccurs="0"/>
-			<xs:element name="digitalmaximum" type="xs:integer" minOccurs="0"/>
-			<xs:element name="prefiltering" type="xs:string" minOccurs="0"/>
-			<xs:element name="samplesinrecord" type="xs:integer" minOccurs="0"/>
-			<xs:element name="reserved" type="xs:string" minOccurs="0"/>
-			<xs:element name="comment" type="xs:string" minOccurs="0"/>
-		</xs:sequence>
 	</xs:complexType>
  </xs:schema>

--- a/src/main/resources/schemas/snet01/snet01.xsd
+++ b/src/main/resources/schemas/snet01/snet01.xsd
@@ -3,7 +3,6 @@
     <xs:import namespace="http://nrg.wustl.edu/xnat" schemaLocation="../xnat/xnat.xsd"/>
 	<xs:element name="SleepResearchSession" type="snet01:sleepResearchSessionData"/>         
 	<xs:element name="PSGScan" type="snet01:psgScanData"/>
-	<xs:element name="PSGEDFData" type="snet01:psgEDFData"/>
 	<xs:element name="PSGRecordData" type="snet01:psgRecordData"/>
 
 	<xs:complexType name="sleepResearchSessionData">
@@ -34,40 +33,6 @@
 					<xs:element name="numberofsignalsindatarecord" type="xs:integer" minOccurs="0"/>
 					<xs:element name="psgdevice" type="xs:string" minOccurs="0"/>  
 					<xs:element name="durationofrecordhours" type="xs:float" minOccurs="0"/>
-					<xs:element name="continuousdataflag" type="xs:integer" minOccurs="0"/> 
-					<xs:element name="comment" type="xs:string" minOccurs="0"/> 
-					<xs:element name="records" minOccurs="0" maxOccurs="unbounded">
-						<xs:complexType>
-							<xs:sequence>
-								<xs:element name="record" type="snet01:psgRecordData" minOccurs="0" maxOccurs="unbounded">
-								</xs:element>
-							</xs:sequence>
-						</xs:complexType>
-					</xs:element>
-				</xs:sequence>
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-
-	<xs:complexType name="psgEDFData">
-		<xs:annotation>
-			<xs:documentation>Derived EDF from Polysomnographic scan</xs:documentation>
-		</xs:annotation>
-		<xs:complexContent>
-			<xs:extension base="xnat:reconstructedImageData">
-				<xs:sequence>
-					<xs:element name="edfversion" type="xs:float" minOccurs="0"/>
-					<xs:element name="patientid" type="xs:string" minOccurs="0"/>
-					<xs:element name="localrecordid" type="xs:string" minOccurs="0"/>
-					<xs:element name="recordingstartdate" type="xs:string" minOccurs="0"/>
-					<xs:element name="recordingstarttime" type="xs:string" minOccurs="0"/>
-					<xs:element name="numberofheaderbytes" type="xs:integer" minOccurs="0"/>
-					<xs:element name="reservedheaderfield" type="xs:string" minOccurs="0"/>
-					<xs:element name="numberofdatarecords" type="xs:integer" minOccurs="0"/>
-					<xs:element name="durationofdatarecordseconds" type="xs:float" minOccurs="0"/>
-					<xs:element name="numberofsignalsindatarecord" type="xs:integer" minOccurs="0"/>
-					<xs:element name="psgdevice" type="xs:string" minOccurs="0"/>  
-					<xs:element name="durationofrecordminutes" type="xs:float" minOccurs="0"/>
 					<xs:element name="continuousdataflag" type="xs:integer" minOccurs="0"/> 
 					<xs:element name="comment" type="xs:string" minOccurs="0"/> 
 					<xs:element name="records" minOccurs="0" maxOccurs="unbounded">


### PR DESCRIPTION
refactor psgRecordData into psgScanData and use uniqueComposite to
ensure that record labels are unique, and therefore not duplicated on
update.

This also required the psgScanData velocity template to be updated